### PR TITLE
Поддержка php 7.2

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -108,7 +108,7 @@ class Client extends Resty
      * Overridden method to decode JSON to array instead of stdClass.
      *
      * @param  string        $resp
-     * @return object|string
+     * @return Obj|string
      */
     protected function processResponseBody($resp)
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -528,33 +528,33 @@ class Container
      * new one
      *
      * @param  string                   $name
-     * @return \OpenStackStorage\Object
+     * @return \OpenStackStorage\Obj
      */
     public function createObject($name)
     {
-        return new Object($this, $name);
+        return new Obj($this, $name);
     }
 
     /**
      * Return an \OpenStackStorage\Object instance for an existing storage object.
      *
      * @param  string                                    $name
-     * @return \OpenStackStorage\Object
+     * @return \OpenStackStorage\Obj
      * @throws \OpenStackStorage\Exceptions\NoSuchObject
      */
     public function getObject($name)
     {
-        return new Object($this, $name, true);
+        return new Obj($this, $name, true);
     }
 
     /**
      * Permanently remove a storage object.
      *
-     * @param string|\OpenStackStorage\Object $name
+     * @param string|\OpenStackStorage\Obj $name
      */
     public function deleteObject($name)
     {
-        if (is_object($name) && $name instanceof Object) {
+        if (is_object($name) && $name instanceof Obj) {
             $name = $name->getName();
         }
 
@@ -566,14 +566,14 @@ class Container
      *
      * @see \OpenStackStorage\Container::$allowedParameters
      * @param  array                      $parameters
-     * @return \OpenStackStorage\Object[]
+     * @return \OpenStackStorage\Obj[]
      */
     public function getObjects(array $parameters = array())
     {
         $objects = array();
 
         foreach ($this->getObjectsInfo($parameters) as $record) {
-            $objects[] = new Object($this, null, false, $record);
+            $objects[] = new Obj($this, null, false, $record);
         }
 
         return $objects;

--- a/src/Obj.php
+++ b/src/Obj.php
@@ -11,7 +11,7 @@ namespace OpenStackStorage;
 /**
  * Storage data representing an object, (metadata and data).
  */
-class Object
+class Obj
 {
 
     /**

--- a/tests/src/ObjectTest.php
+++ b/tests/src/ObjectTest.php
@@ -15,15 +15,15 @@ class ObjectTest extends Base
     protected $objName = 'ipsum.txt';
 
     /**
-     * @see \OpenStackStorage\Object::getName()
-     * @see \OpenStackStorage\Object::getContentType()
-     * @see \OpenStackStorage\Object::getSize()
+     * @see \OpenStackStorage\Obj::getName()
+     * @see \OpenStackStorage\Obj::getContentType()
+     * @see \OpenStackStorage\Obj::getSize()
      */
     public function testObject()
     {
         $object = self::$connection->getContainer($this->containerName)->getObject($this->objName);
 
-        $this->assertInstanceOf('\OpenStackStorage\Object', $object);
+        $this->assertInstanceOf('\OpenStackStorage\Obj', $object);
         $this->assertEquals($this->objName, $object->getName());
         $this->assertEquals('text/plain', $object->getContentType());
         $this->assertEquals(


### PR DESCRIPTION
На php 7.2 выдаёт ошибку - 
Cannot use 'Object' as class name as it is reserved in .../endeveit/open-stack-storage/src/Object.php on line 14